### PR TITLE
Handle `open Lwt` and `include Lwt`

### DIFF
--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -436,16 +436,31 @@ let rewrite_type ~backend ~state typ =
           | _ -> None)
   | _ -> None
 
+(** Remove [open] and [include] items. *)
 let remove_lwt_opens ~state stri =
   match stri.pstr_desc with
   | Pstr_open { popen_expr = { pmod_desc = Pmod_ident lid; _ }; _ }
+  | Pstr_include { pincl_mod = { pmod_desc = Pmod_ident lid; _ }; _ }
     when Occ.pop state lid ->
       false
   | _ -> true
 
+(** Same as [remove_lwt_opens] for signatures. *)
 let remove_lwt_opens_sg ~state sgi =
   match sgi.psig_desc with
-  | Psig_open { popen_expr = lid; _ } when Occ.pop state lid -> false
+  | Psig_open { popen_expr = lid; _ }
+  | Psig_include
+      {
+        pincl_mod =
+          {
+            pmty_desc =
+              Pmty_ident lid | Pmty_typeof { pmod_desc = Pmod_ident lid; _ };
+            _;
+          };
+        _;
+      }
+    when Occ.pop state lid ->
+      false
   | _ -> true
 
 let add_extra_opens ~backend str =

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -390,6 +390,10 @@ let rewrite_expression ~backend ~state exp =
       Occ.may_rewrite state let_.pbop_op
         (rewrite_letop ~backend ~state let_ ands body)
   | Pexp_sequence (lhs, rhs) when can_simply_sequence ~state rhs -> Some lhs
+  | Pexp_open (lid, rhs)
+  | Pexp_letopen ({ popen_expr = { pmod_desc = Pmod_ident lid; _ }; _ }, rhs)
+    when Occ.pop state lid ->
+      Some rhs
   | _ -> None
 
 let rewrite_pattern ~backend ~state pat =

--- a/lib/migrate_utils/migrate_utils.ml
+++ b/lib/migrate_utils/migrate_utils.ml
@@ -49,8 +49,9 @@ module Occ = struct
   let remove state lid = Hashtbl.remove state.occ (Loc.of_location lid.loc)
 
   let pop state lid =
-    if Hashtbl.mem state.occ (Loc.of_location lid.loc) then (
-      remove state lid;
+    let loc = Loc.of_location lid.loc in
+    if Hashtbl.mem state.occ loc then (
+      Hashtbl.remove state.occ loc;
       true)
     else false
 

--- a/lib/migrate_utils/ocaml_index_utils.ml
+++ b/lib/migrate_utils/ocaml_index_utils.ml
@@ -85,6 +85,9 @@ let uid_map_of_unit ~packages ~units =
   List.iter
     (fun (unit_name, cmt) ->
       let cmt = Cmt_format.read_cmt cmt in
+      Tbl.replace tbl
+        (Shape.Uid.of_compilation_unit_id (Ident.create_persistent unit_name))
+        (`Found (unit_name, ""));
       Tbl.iter
         (fun uid decl -> Tbl.replace tbl uid (ident_of_decl ~unit_name decl))
         cmt.cmt_uid_to_decl)

--- a/lib/migrate_utils/ocaml_index_utils.ml
+++ b/lib/migrate_utils/ocaml_index_utils.ml
@@ -68,7 +68,13 @@ let uid_map_of_unit ~packages ~units =
     | Type { typ_id = ident; _ }
     | Value_binding { vb_pat = { pat_desc = Tpat_var (ident, _, _); _ }; _ }
     | Constructor { cd_id = ident; _ }
-    | Extension_constructor { ext_id = ident; _ } ->
+    | Extension_constructor { ext_id = ident; _ }
+    | Module { md_id = Some ident; _ }
+    | Module_substitution { ms_id = ident; _ }
+    | Module_binding { mb_id = Some ident; _ }
+    | Module_type { mtd_id = ident; _ }
+    | Class { ci_id_class = ident; _ }
+    | Class_type { ci_id_class = ident; _ } ->
         `Found (unit_name, Ident.name ident)
     | _ -> `Ignore
   in

--- a/lib/migrate_utils/ocaml_index_utils.ml
+++ b/lib/migrate_utils/ocaml_index_utils.ml
@@ -74,9 +74,13 @@ let uid_map_of_unit ~packages ~units =
     | Module_binding { mb_id = Some ident; _ }
     | Module_type { mtd_id = ident; _ }
     | Class { ci_id_class = ident; _ }
-    | Class_type { ci_id_class = ident; _ } ->
+    | Class_type { ci_id_class = ident; _ }
+    | Label { ld_id = ident; _ } ->
         `Found (unit_name, Ident.name ident)
-    | _ -> `Ignore
+    | Value_binding { vb_pat = { pat_desc = _; _ }; _ }
+    | Module { md_id = None; _ }
+    | Module_binding { mb_id = None; _ } ->
+        `Ignore
   in
   if cmts = [] then
     failwith ("Found no [.cmt] in packages: " ^ String.concat ", " packages);

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -8,7 +8,8 @@ Make a writable directory tree:
   _build/default/bin/.main.eobjs/cctx.ocaml-index
 
   $ lwt-to-direct-style
-  bin/main.ml: (40 occurrences)
+  bin/main.ml: (41 occurrences)
+    Lwt. (bin/main.ml[39,943+5]..[39,943+8])
     Lwt.return (bin/main.ml[9,150+15]..[9,150+25])
     Lwt.return (bin/main.ml[16,317+45]..[16,317+55])
     Lwt.return (bin/main.ml[19,410+24]..[19,410+34])
@@ -49,7 +50,14 @@ Make a writable directory tree:
     Lwt_unix.sleep (bin/main.ml[31,739+8]..[31,739+22])
     Lwt_unix.Timeout (bin/main.ml[37,873+14]..[37,873+30])
     Lwt_unix.with_timeout (bin/main.ml[35,790+15]..[35,790+36])
-  lib/test.ml: (158 occurrences)
+  lib/test.ml: (165 occurrences)
+    Lwt. (lib/test.ml[36,900+11]..[36,900+14])
+    Lwt. (lib/test.ml[55,1445+17]..[55,1445+20])
+    Lwt. (lib/test.ml[64,1681+12]..[64,1681+15])
+    Lwt. (lib/test.ml[161,4292+8]..[161,4292+11])
+    Lwt_fmt. (lib/test.ml[37,918+11]..[37,918+18])
+    Lwt_fmt. (lib/test.ml[56,1469+17]..[56,1469+24])
+    Lwt_fmt. (lib/test.ml[65,1697+12]..[65,1697+19])
     Lwt.t (lib/test.ml[103,2618+35]..[103,2618+40])
     Lwt.t (lib/test.ml[155,4038+13]..[155,4038+18])
     Lwt.t (lib/test.ml[156,4061+21]..[156,4061+26])
@@ -228,7 +236,11 @@ Make a writable directory tree:
   $ lwt-to-direct-style --migrate
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
-  Warning: lib/test.ml: 5 occurrences have not been rewritten.
+  Warning: lib/test.ml: 9 occurrences have not been rewritten.
+    Lwt. (line 55 column 18)
+    Lwt_fmt. (line 56 column 18)
+    Lwt. (line 64 column 13)
+    Lwt_fmt. (line 65 column 13)
     Lwt.<?> (line 113 column 11)
     Lwt.choose (line 115 column 9)
     Lwt_list.iteri_p (line 129 column 9)
@@ -272,8 +284,6 @@ Make a writable directory tree:
     with
     | v -> v
     | exception Eio.Time.Timeout -> 0
-  
-  open Lwt
   
   let _ = match x with 0 -> true | _ -> false
   let _ = print_endline "Hello"
@@ -334,8 +344,6 @@ Make a writable directory tree:
           "3")
   
   let lwt_calls_open () =
-    let open Lwt in
-    let open Lwt_fmt in
     match
       Format.printf "1";
       Format.printf "2";
@@ -568,7 +576,7 @@ Make a writable directory tree:
     x
   
   let i : (unit Promise.t -> unit) -> unit = fun f -> f x
-  let _ = Lwt.(())
+  let _ = ()
   let _ = fun x1 x2 -> x2 x1
   let _ = ( let* )
 

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -8,7 +8,7 @@ Make a writable directory tree:
   _build/default/bin/.main.eobjs/cctx.ocaml-index
 
   $ lwt-to-direct-style
-  bin/main.ml: (39 occurrences)
+  bin/main.ml: (40 occurrences)
     Lwt.return (bin/main.ml[9,150+15]..[9,150+25])
     Lwt.return (bin/main.ml[16,317+45]..[16,317+55])
     Lwt.return (bin/main.ml[19,410+24]..[19,410+34])
@@ -40,6 +40,7 @@ Make a writable directory tree:
     Lwt.>>= (bin/main.ml[41,953+10]..[41,953+13])
     Lwt.let* (bin/main.ml[6,62+6]..[6,62+10])
     Lwt.let+ (bin/main.ml[7,108+6]..[7,108+10])
+    Lwt.Syntax (bin/main.ml[1,0+5]..[1,0+15])
     Lwt_fmt.printf (bin/main.ml[6,62+16]..[6,62+30])
     Lwt_fmt.printf (bin/main.ml[11,194+23]..[11,194+37])
     Lwt_fmt.printf (bin/main.ml[29,686+8]..[29,686+22])
@@ -48,7 +49,7 @@ Make a writable directory tree:
     Lwt_unix.sleep (bin/main.ml[31,739+8]..[31,739+22])
     Lwt_unix.Timeout (bin/main.ml[37,873+14]..[37,873+30])
     Lwt_unix.with_timeout (bin/main.ml[35,790+15]..[35,790+36])
-  lib/test.ml: (150 occurrences)
+  lib/test.ml: (153 occurrences)
     Lwt.t (lib/test.ml[103,2618+35]..[103,2618+40])
     Lwt.t (lib/test.ml[155,4038+13]..[155,4038+18])
     Lwt.t (lib/test.ml[156,4061+21]..[156,4061+26])
@@ -144,6 +145,8 @@ Make a writable directory tree:
     Lwt.<&> (lib/test.ml[33,820+2]..[33,820+5])
     Lwt.<&> (lib/test.ml[60,1582+2]..[60,1582+5])
     Lwt.<?> (lib/test.ml[113,2948+10]..[113,2948+13])
+    Lwt.Infix (lib/test.ml[1,0+5]..[1,0+14])
+    Lwt.Infix (lib/test.ml[57,1497+11]..[57,1497+18])
     Lwt.let* (lib/test.ml[17,428+2]..[17,428+6])
     Lwt.let* (lib/test.ml[18,441+4]..[18,441+8])
     Lwt.let* (lib/test.ml[22,555+2]..[22,555+6])
@@ -162,6 +165,7 @@ Make a writable directory tree:
     Lwt.and* (lib/test.ml[27,679+2]..[27,679+6])
     Lwt.let+ (lib/test.ml[19,477+4]..[19,477+8])
     Lwt.let+ (lib/test.ml[24,604+4]..[24,604+8])
+    Lwt.Syntax (lib/test.ml[2,15+5]..[2,15+15])
     Lwt_condition.create (lib/test.ml[131,3409+8]..[131,3409+28])
     Lwt_condition.wait (lib/test.ml[132,3441+14]..[132,3441+32])
     Lwt_condition.wait (lib/test.ml[133,3479+20]..[133,3479+38])
@@ -219,7 +223,8 @@ Make a writable directory tree:
   $ lwt-to-direct-style --migrate
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
-  Warning: lib/test.ml: 4 occurrences have not been rewritten.
+  Warning: lib/test.ml: 5 occurrences have not been rewritten.
+    Lwt.Infix (line 57 column 12)
     Lwt.<?> (line 113 column 11)
     Lwt.choose (line 115 column 9)
     Lwt_list.iteri_p (line 129 column 9)
@@ -230,8 +235,6 @@ Make a writable directory tree:
   Formatted 3 files
 
   $ cat bin/main.ml
-  open Lwt.Syntax
-  
   let _main () =
     match
       let () = Format.printf "Main.main" in
@@ -281,8 +284,6 @@ Make a writable directory tree:
 
   $ cat lib/test.ml
   open Eio.Std
-  open Lwt.Infix
-  open Lwt.Syntax
   
   let lwt_calls () =
     match

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -49,7 +49,7 @@ Make a writable directory tree:
     Lwt_unix.sleep (bin/main.ml[31,739+8]..[31,739+22])
     Lwt_unix.Timeout (bin/main.ml[37,873+14]..[37,873+30])
     Lwt_unix.with_timeout (bin/main.ml[35,790+15]..[35,790+36])
-  lib/test.ml: (153 occurrences)
+  lib/test.ml: (158 occurrences)
     Lwt.t (lib/test.ml[103,2618+35]..[103,2618+40])
     Lwt.t (lib/test.ml[155,4038+13]..[155,4038+18])
     Lwt.t (lib/test.ml[156,4061+21]..[156,4061+26])
@@ -81,6 +81,7 @@ Make a writable directory tree:
     Lwt.return (lib/test.ml[111,2902+8]..[111,2902+18])
     Lwt.return (lib/test.ml[117,3039+19]..[117,3039+29])
     Lwt.return (lib/test.ml[140,3706+27]..[140,3706+37])
+    Lwt.return (lib/test.ml[161,4292+13]..[161,4292+19])
     Lwt.fail (lib/test.ml[109,2841+8]..[109,2841+16])
     Lwt.fail_with (lib/test.ml[110,2868+8]..[110,2868+21])
     Lwt.fail_invalid_arg (lib/test.ml[118,3074+32]..[118,3074+52])
@@ -137,6 +138,7 @@ Make a writable directory tree:
     Lwt.>>= (lib/test.ml[78,2113+2]..[78,2113+5])
     Lwt.>>= (lib/test.ml[88,2290+2]..[88,2290+5])
     Lwt.>>= (lib/test.ml[158,4164+59]..[158,4164+62])
+    Lwt.>>= (lib/test.ml[162,4316+19]..[162,4316+26])
     Lwt.=<< (lib/test.ml[111,2902+19]..[111,2902+22])
     Lwt.>|= (lib/test.ml[32,766+36]..[32,766+39])
     Lwt.>|= (lib/test.ml[46,1188+15]..[46,1188+32])
@@ -147,6 +149,7 @@ Make a writable directory tree:
     Lwt.<?> (lib/test.ml[113,2948+10]..[113,2948+13])
     Lwt.Infix (lib/test.ml[1,0+5]..[1,0+14])
     Lwt.Infix (lib/test.ml[57,1497+11]..[57,1497+18])
+    Lwt.Infix (lib/test.ml[162,4316+8]..[162,4316+17])
     Lwt.let* (lib/test.ml[17,428+2]..[17,428+6])
     Lwt.let* (lib/test.ml[18,441+4]..[18,441+8])
     Lwt.let* (lib/test.ml[22,555+2]..[22,555+6])
@@ -160,12 +163,14 @@ Make a writable directory tree:
     Lwt.let* (lib/test.ml[104,2675+2]..[104,2675+6])
     Lwt.let* (lib/test.ml[105,2725+2]..[105,2725+6])
     Lwt.let* (lib/test.ml[106,2798+2]..[106,2798+6])
+    Lwt.let* (lib/test.ml[163,4344+20]..[163,4344+28])
     Lwt.and* (lib/test.ml[21,521+2]..[21,521+6])
     Lwt.and* (lib/test.ml[26,648+2]..[26,648+6])
     Lwt.and* (lib/test.ml[27,679+2]..[27,679+6])
     Lwt.let+ (lib/test.ml[19,477+4]..[19,477+8])
     Lwt.let+ (lib/test.ml[24,604+4]..[24,604+8])
     Lwt.Syntax (lib/test.ml[2,15+5]..[2,15+15])
+    Lwt.Syntax (lib/test.ml[163,4344+8]..[163,4344+18])
     Lwt_condition.create (lib/test.ml[131,3409+8]..[131,3409+28])
     Lwt_condition.wait (lib/test.ml[132,3441+14]..[132,3441+32])
     Lwt_condition.wait (lib/test.ml[133,3479+20]..[133,3479+38])
@@ -224,11 +229,11 @@ Make a writable directory tree:
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
   Warning: lib/test.ml: 5 occurrences have not been rewritten.
-    Lwt.Infix (line 57 column 12)
     Lwt.<?> (line 113 column 11)
     Lwt.choose (line 115 column 9)
     Lwt_list.iteri_p (line 129 column 9)
     Lwt.Fail (line 147 column 5)
+    Lwt.let* (line 163 column 21)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
     Lwt_mutex.t (line 2 column 10)
     Lwt_mutex.t (line 3 column 10)
@@ -353,7 +358,6 @@ Make a writable directory tree:
   let lwt_calls_alias () =
     let module L = Lwt in
     let module F = Lwt_fmt in
-    let open L.Infix in
     Fiber.pair
       (fun () ->
         Format.printf
@@ -564,6 +568,9 @@ Make a writable directory tree:
     x
   
   let i : (unit Promise.t -> unit) -> unit = fun f -> f x
+  let _ = Lwt.(())
+  let _ = fun x1 x2 -> x2 x1
+  let _ = ( let* )
 
   $ cat lib/test.mli
   open Eio.Std

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -50,11 +50,12 @@ Make a writable directory tree:
     Lwt_unix.sleep (bin/main.ml[31,739+8]..[31,739+22])
     Lwt_unix.Timeout (bin/main.ml[37,873+14]..[37,873+30])
     Lwt_unix.with_timeout (bin/main.ml[35,790+15]..[35,790+36])
-  lib/test.ml: (165 occurrences)
+  lib/test.ml: (169 occurrences)
     Lwt. (lib/test.ml[36,900+11]..[36,900+14])
     Lwt. (lib/test.ml[55,1445+17]..[55,1445+20])
     Lwt. (lib/test.ml[64,1681+12]..[64,1681+15])
     Lwt. (lib/test.ml[161,4292+8]..[161,4292+11])
+    Lwt. (lib/test.ml[172,4457+10]..[172,4457+13])
     Lwt_fmt. (lib/test.ml[37,918+11]..[37,918+18])
     Lwt_fmt. (lib/test.ml[56,1469+17]..[56,1469+24])
     Lwt_fmt. (lib/test.ml[65,1697+12]..[65,1697+19])
@@ -158,6 +159,7 @@ Make a writable directory tree:
     Lwt.Infix (lib/test.ml[1,0+5]..[1,0+14])
     Lwt.Infix (lib/test.ml[57,1497+11]..[57,1497+18])
     Lwt.Infix (lib/test.ml[162,4316+8]..[162,4316+17])
+    Lwt.Infix (lib/test.ml[173,4471+10]..[173,4471+19])
     Lwt.let* (lib/test.ml[17,428+2]..[17,428+6])
     Lwt.let* (lib/test.ml[18,441+4]..[18,441+8])
     Lwt.let* (lib/test.ml[22,555+2]..[22,555+6])
@@ -179,6 +181,8 @@ Make a writable directory tree:
     Lwt.let+ (lib/test.ml[24,604+4]..[24,604+8])
     Lwt.Syntax (lib/test.ml[2,15+5]..[2,15+15])
     Lwt.Syntax (lib/test.ml[163,4344+8]..[163,4344+18])
+    Lwt.Syntax (lib/test.ml[167,4401+12]..[167,4401+22])
+    Lwt.Syntax (lib/test.ml[174,4491+10]..[174,4491+20])
     Lwt_condition.create (lib/test.ml[131,3409+8]..[131,3409+28])
     Lwt_condition.wait (lib/test.ml[132,3441+14]..[132,3441+32])
     Lwt_condition.wait (lib/test.ml[133,3479+20]..[133,3479+38])
@@ -216,7 +220,8 @@ Make a writable directory tree:
     Lwt_mutex.lock (lib/test.ml[136,3609+8]..[136,3609+22])
     Lwt_mutex.unlock (lib/test.ml[137,3634+8]..[137,3634+24])
     Lwt_mutex.with_lock (lib/test.ml[138,3661+8]..[138,3661+27])
-  lib/test.mli: (15 occurrences)
+  lib/test.mli: (17 occurrences)
+    Lwt. (lib/test.mli[12,364+25]..[12,364+28])
     Lwt.t (lib/test.mli[1,0+34]..[1,0+39])
     Lwt.t (lib/test.mli[2,40+53]..[2,40+58])
     Lwt.t (lib/test.mli[3,99+60]..[3,99+65])
@@ -227,6 +232,7 @@ Make a writable directory tree:
     Lwt.t (lib/test.mli[7,238+37]..[7,238+42])
     Lwt.t (lib/test.mli[8,281+14]..[8,281+19])
     Lwt.t (lib/test.mli[9,318+24]..[9,318+29])
+    Lwt.Infix (lib/test.mli[13,393+25]..[13,393+34])
     Lwt_condition.t (lib/test.mli[1,0+12]..[1,0+27])
     Lwt_condition.t (lib/test.mli[2,40+29]..[2,40+44])
     Lwt_condition.t (lib/test.mli[3,99+36]..[3,99+51])
@@ -236,11 +242,9 @@ Make a writable directory tree:
   $ lwt-to-direct-style --migrate
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
-  Warning: lib/test.ml: 9 occurrences have not been rewritten.
+  Warning: lib/test.ml: 7 occurrences have not been rewritten.
     Lwt. (line 55 column 18)
     Lwt_fmt. (line 56 column 18)
-    Lwt. (line 64 column 13)
-    Lwt_fmt. (line 65 column 13)
     Lwt.<?> (line 113 column 11)
     Lwt.choose (line 115 column 9)
     Lwt_list.iteri_p (line 129 column 9)
@@ -379,10 +383,7 @@ Make a writable directory tree:
           "3")
   
   let lwt_calls_include () =
-    let module L = struct
-      include Lwt
-      include Lwt_fmt
-    end in
+    let module L = struct end in
     let open L in
     match
       Format.printf "1";
@@ -579,6 +580,12 @@ Make a writable directory tree:
   let _ = ()
   let _ = fun x1 x2 -> x2 x1
   let _ = ( let* )
+  
+  let _ =
+    let open struct end in
+    ()
+  
+  module M = struct end
 
   $ cat lib/test.mli
   open Eio.Std
@@ -596,3 +603,5 @@ Make a writable directory tree:
   val h : (unit -> unit) -> unit
   val i : (unit Promise.t -> unit) -> unit
   val test : unit -> unit
+  
+  module M : sig end

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
@@ -161,3 +161,15 @@ let i : (unit Lwt.t -> unit) -> unit = fun f -> f x
 let _ = Lwt.(return ())
 let _ = Lwt.Infix.(( >>= ))
 let _ = Lwt.Syntax.(( let* ))
+
+let _ =
+  let open struct
+    include Lwt.Syntax
+  end in
+  ()
+
+module M = struct
+  include Lwt
+  include Lwt.Infix
+  include Lwt.Syntax
+end

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
@@ -157,3 +157,7 @@ let f : unit -> unit Lwt.t = fun () -> x
 let g : unit Lwt.t -> unit = fun y -> Lwt.async (fun () -> y)
 let h : (unit -> unit Lwt.t) -> unit Lwt.t = fun f -> f () >>= fun () -> x
 let i : (unit Lwt.t -> unit) -> unit = fun f -> f x
+
+let _ = Lwt.(return ())
+let _ = Lwt.Infix.(( >>= ))
+let _ = Lwt.Syntax.(( let* ))

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.mli
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.mli
@@ -7,3 +7,8 @@ val g : unit Lwt.t -> unit
 val h : (unit -> unit Lwt.t) -> unit Lwt.t
 val i : (unit Lwt.t -> unit) -> unit
 val test : unit -> unit Lwt.t
+
+module M : sig
+  include module type of Lwt
+  include module type of Lwt.Infix
+end


### PR DESCRIPTION
This makes sure that local and global opens, as well as includes are removed during the transformation.