### PR TITLE
Translate some `Lwt_unix` and `Lwt_io` code to Eio

### DIFF
--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -528,6 +528,7 @@ let rewrite_type ~backend ~state typ =
                  | "group_entry" ) as tname) ),
               params ) ->
               Some (mk_typ_constr ~params [ "Unix"; tname ])
+          | ("Lwt_io", "output_channel"), [] -> Some backend#type_out_channel
           | _ -> None)
   | _ -> None
 

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -306,6 +306,13 @@ let rewrite_apply ~backend ~state full_ident args =
       ignore_lblarg "set_flags"
       @@ return (Some (backend#of_unix_file_descr ?blocking fd))
   | "Lwt_unix", "close" -> take @@ fun fd -> return (Some (backend#fd_close fd))
+  (* [Lwt_unix] contains functions exactly equivalent to functions of the same
+     name in [Unix]. *)
+  | "Lwt_unix", ("getaddrinfo" as fname) ->
+      Format.kasprintf (add_comment state)
+        "This call to [Unix.%s] was [Lwt_unix.%s] before the rewrite." fname
+        fname;
+      transparent [ "Unix"; fname ]
   | "Lwt_condition", "create" ->
       take @@ fun _unit -> return (Some (backend#condition_create ()))
   | "Lwt_condition", "wait" ->

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -319,6 +319,12 @@ let rewrite_apply ~backend ~state full_ident args =
   | "Lwt_mutex", "with_lock" ->
       take @@ fun t ->
       take @@ fun f -> return (Some (backend#mutex_with_lock t f))
+  | "Lwt_io", "read_into" ->
+      take @@ fun input ->
+      take @@ fun buffer ->
+      take @@ fun buf_off ->
+      take @@ fun buf_len ->
+      return (Some (backend#io_read input buffer buf_off buf_len))
   | _ -> return None
 
 (** Transform a [binding_op] into a [pattern] and an [expression] while

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -333,6 +333,8 @@ let rewrite_apply ~backend ~state full_ident args =
       take @@ fun buf_off ->
       take @@ fun buf_len ->
       return (Some (backend#io_read input buffer buf_off buf_len))
+  | "Lwt_main", "run" ->
+      take @@ fun promise -> return (Some (backend#main_run promise))
   | _ -> return None
 
 (** Transform a [binding_op] into a [pattern] and an [expression] while

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -360,6 +360,9 @@ let rewrite_apply ~backend ~state full_ident args =
       @@ take_lbl "mode"
       @@ fun mode ->
       take @@ fun fd -> return (lwt_io_of_fd ~backend ~state ~mode fd)
+  | "Lwt_io", "write" ->
+      take @@ fun chan ->
+      take @@ fun str -> return (Some (backend#io_write_str chan str))
   | "Lwt_main", "run" ->
       take @@ fun promise -> return (Some (backend#main_run promise))
   | _ -> return None

--- a/bin/lwt_to_direct_style/ast_rewrite.ml
+++ b/bin/lwt_to_direct_style/ast_rewrite.ml
@@ -305,6 +305,7 @@ let rewrite_apply ~backend ~state full_ident args =
       take_lblopt "blocking" @@ fun blocking ->
       ignore_lblarg "set_flags"
       @@ return (Some (backend#of_unix_file_descr ?blocking fd))
+  | "Lwt_unix", "close" -> take @@ fun fd -> return (Some (backend#fd_close fd))
   | "Lwt_condition", "create" ->
       take @@ fun _unit -> return (Some (backend#condition_create ()))
   | "Lwt_condition", "wait" ->

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -150,4 +150,6 @@ let eio add_comment =
       add_comment_dropped_exp ~label:"buffer offset" buf_offset;
       add_comment_dropped_exp ~label:"buffer length" buf_len;
       mk_apply_simple [ "Eio"; "Flow"; "single_read" ] [ input; buffer ]
+
+    method fd_close fd = mk_apply_simple [ "Eio_unix"; "Fd" ] [ fd ]
   end

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -169,10 +169,18 @@ let eio add_comment =
            [ "Std"; "r" ])
 
     method output_io_of_fd fd =
+      add_comment
+        "This creates a closeable [Flow.sink] resource but write operations \
+         are rewritten to calls to [Buf_write].\n\
+        \        You might want to use [Buf_write.with_flow sink (fun \
+         buf_write -> ...)].";
       Exp.constraint_
         (mk_apply_simple [ "Eio_unix"; "Net"; "import_socket_stream" ] [ fd ])
         (mk_typ_constr
            ~params:
              [ mk_poly_variant [ ("W", []); ("Flow", []); ("Close", []) ] ]
            [ "Std"; "r" ])
+
+    method io_write_str chan str =
+      mk_apply_simple [ "Eio"; "Buf_write"; "string" ] [ chan; str ]
   end

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -120,4 +120,22 @@ let eio add_comment =
       mk_typ_constr ~params:[ param ] (promise_ident "t")
 
     method direct_style_type param = param
+
+    method of_unix_file_descr ?blocking fd =
+      add_comment "[sw] must be propagated here.";
+      let blocking_arg =
+        let lbl = mk_loc "blocking" in
+        match blocking with
+        | Some (expr, `Lbl) -> [ (Labelled lbl, expr) ]
+        | Some (expr, `Opt) -> [ (Optional lbl, expr) ]
+        | None -> []
+      in
+      mk_apply_ident
+        [ "Eio_unix"; "Fd"; "of_unix" ]
+        ([ (Labelled (mk_loc "sw"), mk_exp_ident [ "sw" ]) ]
+        @ blocking_arg
+        @ [
+            (Labelled (mk_loc "close_unix"), mk_constr_exp [ "true" ]);
+            (Nolabel, fd);
+          ])
   end

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -159,4 +159,20 @@ let eio add_comment =
          [fun].";
       mk_apply_simple [ "Eio_main"; "run" ]
         [ mk_fun ~arg_name:"env" (fun _env -> promise) ]
+
+    method input_io_of_fd fd =
+      Exp.constraint_
+        (mk_apply_simple [ "Eio_unix"; "Net"; "import_socket_stream" ] [ fd ])
+        (mk_typ_constr
+           ~params:
+             [ mk_poly_variant [ ("R", []); ("Flow", []); ("Close", []) ] ]
+           [ "Std"; "r" ])
+
+    method output_io_of_fd fd =
+      Exp.constraint_
+        (mk_apply_simple [ "Eio_unix"; "Net"; "import_socket_stream" ] [ fd ])
+        (mk_typ_constr
+           ~params:
+             [ mk_poly_variant [ ("W", []); ("Flow", []); ("Close", []) ] ]
+           [ "Std"; "r" ])
   end

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -66,8 +66,7 @@ let eio add_comment =
       let clock = Exp.send (mk_exp_ident [ "env" ]) (mk_loc "mono_clock") in
       mk_apply_simple [ "Eio"; "Time"; "with_timeout_exn" ] [ clock; d; f ]
 
-    method timeout_exn =
-      Pat.construct (mk_longident [ "Eio"; "Time"; "Timeout" ]) None
+    method timeout_exn = mk_longident [ "Eio"; "Time"; "Timeout" ]
 
     method condition_create () =
       mk_apply_simple [ "Eio"; "Condition"; "create" ] [ mk_unit_val ]

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -151,4 +151,12 @@ let eio add_comment =
       mk_apply_simple [ "Eio"; "Flow"; "single_read" ] [ input; buffer ]
 
     method fd_close fd = mk_apply_simple [ "Eio_unix"; "Fd" ] [ fd ]
+
+    method main_run promise =
+      add_comment
+        "[Eio_main.run] argument used to be a [Lwt] promise and is now a \
+         [fun]. Make sure no asynchronous or IO calls are done outside of this \
+         [fun].";
+      mk_apply_simple [ "Eio_main"; "run" ]
+        [ mk_fun ~arg_name:"env" (fun _env -> promise) ]
   end

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -183,4 +183,6 @@ let eio add_comment =
 
     method io_write_str chan str =
       mk_apply_simple [ "Eio"; "Buf_write"; "string" ] [ chan; str ]
+
+    method type_out_channel = mk_typ_constr [ "Eio"; "Buf_write"; "t" ]
   end

--- a/lib/migrate_utils/ocaml_index_utils.ml
+++ b/lib/migrate_utils/ocaml_index_utils.ml
@@ -67,6 +67,8 @@ let uid_map_of_unit ~packages ~units =
     | Typedtree.Value { val_id = ident; _ }
     | Type { typ_id = ident; _ }
     | Value_binding { vb_pat = { pat_desc = Tpat_var (ident, _, _); _ }; _ }
+    | Value_binding
+        { vb_pat = { pat_desc = Tpat_alias (_, ident, _, _); _ }; _ }
     | Constructor { cd_id = ident; _ }
     | Extension_constructor { ext_id = ident; _ }
     | Module { md_id = Some ident; _ }

--- a/lib/ocamlformat_utils/ast_utils.ml
+++ b/lib/ocamlformat_utils/ast_utils.ml
@@ -53,6 +53,18 @@ let mk_lblopt s = Optional (mk_loc s)
 let mk_pat_some arg = mk_constr_pat ~arg [ "Some" ]
 let mk_pat_none = mk_constr_pat [ "None" ]
 
+let mk_row_field ?(loc = !default_loc) ?(attrs = []) desc =
+  { Parsetree.prf_desc = desc; prf_loc = loc; prf_attributes = attrs }
+
+let mk_poly_variant ?(open_ = false) ?labels ?(inherit_ = []) vars =
+  let mk_rtag (var, args) =
+    mk_row_field (Rtag (mk_loc (mk_loc var), List.is_empty args, args))
+  in
+  let mk_inherit t = mk_row_field (Rinherit t) in
+  let flag = if open_ then Open else Closed in
+  let constrs = List.map mk_rtag vars @ List.map mk_inherit inherit_ in
+  Typ.variant constrs flag labels
+
 (* Exp *)
 
 let mk_const_string s = Exp.constant (Const.string s)

--- a/lib/ocamlformat_utils/ast_utils.ml
+++ b/lib/ocamlformat_utils/ast_utils.ml
@@ -122,7 +122,10 @@ let mk_binding_op ?(loc = !default_loc) ?(is_pun = false) op pat ?(args = [])
     ?(typ = None) exp =
   Exp.binding_op op pat args typ exp is_pun loc
 
-let mk_apply_ident ident args = Exp.apply (mk_exp_ident ident) args
+(* Generates a [Pexp_ident] when [args] is the empty list. *)
+let mk_apply_ident ident args =
+  let ident = mk_exp_ident ident in
+  match args with [] -> ident | _ -> Exp.apply ident args
 
 let mk_apply_simple f_ident args =
   mk_apply_ident f_ident (List.map (fun x -> (Nolabel, x)) args)

--- a/lib/ocamlformat_utils/ocamlformat_utils.mli
+++ b/lib/ocamlformat_utils/ocamlformat_utils.mli
@@ -17,6 +17,9 @@ type modify_ast = {
   signature : signature -> signature * Cmt.t list;
 }
 
+val format_expression : expression -> string
+(** Format a fragment of AST, useful for messages. *)
+
 val format_in_place :
   file:string -> modify_ast:modify_ast -> (unit, [ `Msg of string ]) result
 (** Format the content of and overwrite [file]. [modify_ast] can be used to

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -220,10 +220,14 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (3 occurrences)
-    Lwt_io (line 4 column 6)
-    Lwt_io.of_fd (line 4 column 14)
-    Lwt_unix.of_unix_file_descr (line 3 column 6)
+  lib/test_lwt_unix.ml: (7 occurrences)
+    Lwt_io (line 7 column 8)
+    Lwt.return (line 11 column 3)
+    Lwt.let* (line 10 column 3)
+    Lwt.Syntax (line 1 column 6)
+    Lwt_io.of_fd (line 7 column 16)
+    Lwt_io.read_into (line 10 column 19)
+    Lwt_unix.of_unix_file_descr (line 6 column 8)
   lib/test.mli: (17 occurrences)
     Lwt (line 12 column 26)
     Lwt.t (line 1 column 35)
@@ -256,7 +260,7 @@ Make a writable directory tree:
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
   Warning: lib/test_lwt_unix.ml: 1 occurrences have not been rewritten.
-    Lwt_io.of_fd (line 4 column 14)
+    Lwt_io.of_fd (line 7 column 16)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
     Lwt_mutex.t (line 2 column 10)
     Lwt_mutex.t (line 3 column 10)
@@ -613,12 +617,23 @@ Make a writable directory tree:
   module M : sig end
 
   $ cat lib/test_lwt_unix.ml
-  let _ =
-    (fun ?blocking:x1 ?set_flags:x2 ->
-      Eio_unix.Fd.of_unix ~sw ?blocking:x1 ~close_unix:true
-        (Unix
-         (* TODO: lwt-to-direct-style: [sw] must be propagated here. *)
-         (* TODO: lwt-to-direct-style: Labelled argument ?set_flags was dropped. *).(
-           openfile "foo" [ O_RDWR; O_NONBLOCK; O_APPEND ])
-           0o660))
-    |> of_fd ~mode:input
+  let _f fname =
+    let inp =
+      (fun ?blocking:x1 ?set_flags:x2 ->
+        Eio_unix.Fd.of_unix ~sw ?blocking:x1 ~close_unix:true
+          (Unix
+           (* TODO: lwt-to-direct-style: [sw] must be propagated here. *)
+           (* TODO: lwt-to-direct-style: Labelled argument ?set_flags was dropped. *).(
+             openfile fname [ O_RDWR; O_NONBLOCK; O_APPEND ])
+             0o660))
+      |> of_fd ~mode:input
+    in
+    let buf = Bytes.create 1024 in
+    let _n : int =
+      Eio.Flow.single_read
+        (* TODO: lwt-to-direct-style: [buf] should be a [Cstruct.t]. *)
+        (* TODO: lwt-to-direct-style: Dropped expression (buffer offset): [0]. *)
+        (* TODO: lwt-to-direct-style: Dropped expression (buffer length): [1024]. *)
+        inp buf
+    in
+    ()

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -223,7 +223,7 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (8 occurrences)
+  lib/test_lwt_unix.ml: (13 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
@@ -232,6 +232,11 @@ Make a writable directory tree:
     Lwt_io.read_into (line 10 column 19)
     Lwt_unix.Timeout (line 13 column 9)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
+    Lwt_unix.sockaddr (line 14 column 9)
+    Lwt_unix.ADDR_UNIX (line 14 column 29)
+    Lwt_unix.ADDR_UNIX (line 16 column 6)
+    Lwt_unix.ADDR_INET (line 16 column 29)
+    Lwt_unix.ADDR_INET (line 17 column 3)
   lib/test.mli: (17 occurrences)
     Lwt (line 12 column 26)
     Lwt.t (line 1 column 35)
@@ -652,3 +657,7 @@ Make a writable directory tree:
     ()
   
   let _ = Eio.Time.Timeout
+  let _ : Unix.sockaddr = Unix.ADDR_UNIX ""
+  
+  let (Unix.ADDR_UNIX _ | Unix.ADDR_INET _) =
+    Unix.ADDR_INET (Unix.inet_addr_any, 0)

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -220,6 +220,10 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
+  lib/test_lwt_unix.ml: (3 occurrences)
+    Lwt_io (line 4 column 6)
+    Lwt_io.of_fd (line 4 column 14)
+    Lwt_unix.of_unix_file_descr (line 3 column 6)
   lib/test.mli: (17 occurrences)
     Lwt (line 12 column 26)
     Lwt.t (line 1 column 35)
@@ -240,7 +244,7 @@ Make a writable directory tree:
     Lwt_mutex.t (line 3 column 10)
 
   $ lwt-to-direct-style --migrate
-  Formatted 3 files
+  Formatted 4 files
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
   Warning: lib/test.ml: 7 occurrences have not been rewritten.
@@ -251,6 +255,8 @@ Make a writable directory tree:
     Lwt_list.iteri_p (line 129 column 9)
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
+  Warning: lib/test_lwt_unix.ml: 1 occurrences have not been rewritten.
+    Lwt_io.of_fd (line 4 column 14)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
     Lwt_mutex.t (line 2 column 10)
     Lwt_mutex.t (line 3 column 10)
@@ -605,3 +611,14 @@ Make a writable directory tree:
   val test : unit -> unit
   
   module M : sig end
+
+  $ cat lib/test_lwt_unix.ml
+  let _ =
+    (fun ?blocking:x1 ?set_flags:x2 ->
+      Eio_unix.Fd.of_unix ~sw ?blocking:x1 ~close_unix:true
+        (Unix
+         (* TODO: lwt-to-direct-style: [sw] must be propagated here. *)
+         (* TODO: lwt-to-direct-style: Labelled argument ?set_flags was dropped. *).(
+           openfile "foo" [ O_RDWR; O_NONBLOCK; O_APPEND ])
+           0o660))
+    |> of_fd ~mode:input

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -223,7 +223,7 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (21 occurrences)
+  lib/test_lwt_unix.ml: (22 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
@@ -237,6 +237,7 @@ Make a writable directory tree:
     Lwt_io.of_fd (line 22 column 13)
     Lwt_io.of_fd (line 23 column 13)
     Lwt_io.read_into (line 10 column 19)
+    Lwt_io.write (line 24 column 19)
     Lwt_unix.Timeout (line 13 column 9)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
     Lwt_unix.sockaddr (line 14 column 9)
@@ -677,10 +678,20 @@ Make a writable directory tree:
     Unix.getaddrinfo
   
   let _f fd =
-    (Eio_unix.Net.import_socket_stream fd : [ `W | `Flow | `Close ] Std.r)
+    (Eio_unix.Net.import_socket_stream
+       (* TODO: lwt-to-direct-style: This creates a closeable [Flow.sink] resource but write operations are rewritten to calls to [Buf_write].
+          You might want to use [Buf_write.with_flow sink (fun buf_write -> ...)]. *)
+       fd
+      : [ `W | `Flow | `Close ] Std.r)
   
   let _f fd =
     (Eio_unix.Net.import_socket_stream fd : [ `R | `Flow | `Close ] Std.r)
   
   let _f fd =
-    (Eio_unix.Net.import_socket_stream fd : [ `W | `Flow | `Close ] Std.r)
+    (Eio_unix.Net.import_socket_stream
+       (* TODO: lwt-to-direct-style: This creates a closeable [Flow.sink] resource but write operations are rewritten to calls to [Buf_write].
+          You might want to use [Buf_write.with_flow sink (fun buf_write -> ...)]. *)
+       fd
+      : [ `W | `Flow | `Close ] Std.r)
+  
+  let _f out_chan = Eio.Buf_write.string out_chan "str"

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -223,7 +223,7 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (22 occurrences)
+  lib/test_lwt_unix.ml: (24 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
@@ -232,12 +232,14 @@ Make a writable directory tree:
     Lwt_io.Output (line 23 column 32)
     Lwt_io.input (line 7 column 28)
     Lwt_io.output (line 21 column 32)
+    Lwt_io.output_channel (line 26 column 9)
     Lwt_io.of_fd (line 7 column 16)
     Lwt_io.of_fd (line 21 column 13)
     Lwt_io.of_fd (line 22 column 13)
     Lwt_io.of_fd (line 23 column 13)
     Lwt_io.read_into (line 10 column 19)
     Lwt_io.write (line 24 column 19)
+    Lwt_io.stdout (line 26 column 33)
     Lwt_unix.Timeout (line 13 column 9)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
     Lwt_unix.sockaddr (line 14 column 9)
@@ -276,6 +278,8 @@ Make a writable directory tree:
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
     Lwt.Fail (line 179 column 9)
+  Warning: lib/test_lwt_unix.ml: 1 occurrences have not been rewritten.
+    Lwt_io.stdout (line 26 column 33)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
     Lwt_mutex.t (line 2 column 10)
     Lwt_mutex.t (line 3 column 10)
@@ -695,3 +699,4 @@ Make a writable directory tree:
       : [ `W | `Flow | `Close ] Std.r)
   
   let _f out_chan = Eio.Buf_write.string out_chan "str"
+  let _ : Eio.Buf_write.t = Lwt_io.stdout

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -223,7 +223,7 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (13 occurrences)
+  lib/test_lwt_unix.ml: (14 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
@@ -237,6 +237,7 @@ Make a writable directory tree:
     Lwt_unix.ADDR_UNIX (line 16 column 6)
     Lwt_unix.ADDR_INET (line 16 column 29)
     Lwt_unix.ADDR_INET (line 17 column 3)
+    Lwt_unix.getaddrinfo (line 19 column 9)
   lib/test.mli: (17 occurrences)
     Lwt (line 12 column 26)
     Lwt.t (line 1 column 35)
@@ -661,3 +662,8 @@ Make a writable directory tree:
   
   let (Unix.ADDR_UNIX _ | Unix.ADDR_INET _) =
     Unix.ADDR_INET (Unix.inet_addr_any, 0)
+  
+  let _
+      (* TODO: lwt-to-direct-style: This call to [Unix.getaddrinfo] was [Lwt_unix.getaddrinfo] before the rewrite. *)
+      =
+    Unix.getaddrinfo

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -259,8 +259,6 @@ Make a writable directory tree:
 
   $ lwt-to-direct-style --migrate
   Formatted 4 files
-  Warning: bin/main.ml: 1 occurrences have not been rewritten.
-    Lwt_main.run (line 22 column 10)
   Warning: lib/test.ml: 8 occurrences have not been rewritten.
     Lwt (line 55 column 18)
     Lwt_fmt (line 56 column 18)
@@ -290,7 +288,11 @@ Make a writable directory tree:
     let main () = match None with v -> v in
     match main () with Some _ -> () | None -> () | exception _ -> ()
   
-  let () = Lwt_main.run (main ())
+  let () =
+    Eio_main.run (fun env ->
+        (* TODO: lwt-to-direct-style: [Eio_main.run] argument used to be a [Lwt] promise and is now a [fun]. Make sure no asynchronous or IO calls are done outside of this [fun]. *)
+        main ())
+  
   let _ = None
   let _ = []
   let _ = true

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -50,7 +50,7 @@ Make a writable directory tree:
     Lwt_unix.sleep (line 31 column 9)
     Lwt_unix.Timeout (line 37 column 15)
     Lwt_unix.with_timeout (line 35 column 16)
-  lib/test.ml: (169 occurrences)
+  lib/test.ml: (172 occurrences)
     Lwt (line 36 column 12)
     Lwt (line 55 column 18)
     Lwt (line 64 column 13)
@@ -134,8 +134,11 @@ Make a writable directory tree:
     Lwt.pick (line 95 column 12)
     Lwt.pick (line 96 column 12)
     Lwt.Return (line 146 column 5)
+    Lwt.Return (line 177 column 9)
     Lwt.Fail (line 147 column 5)
+    Lwt.Fail (line 179 column 9)
     Lwt.Sleep (line 148 column 5)
+    Lwt.Sleep (line 178 column 9)
     Lwt.state (line 145 column 9)
     Lwt.pause (line 114 column 9)
     Lwt.(>>=) (line 32 column 3)
@@ -220,13 +223,14 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (7 occurrences)
+  lib/test_lwt_unix.ml: (8 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
     Lwt.Syntax (line 1 column 6)
     Lwt_io.of_fd (line 7 column 16)
     Lwt_io.read_into (line 10 column 19)
+    Lwt_unix.Timeout (line 13 column 9)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
   lib/test.mli: (17 occurrences)
     Lwt (line 12 column 26)
@@ -251,7 +255,7 @@ Make a writable directory tree:
   Formatted 4 files
   Warning: bin/main.ml: 1 occurrences have not been rewritten.
     Lwt_main.run (line 22 column 10)
-  Warning: lib/test.ml: 7 occurrences have not been rewritten.
+  Warning: lib/test.ml: 8 occurrences have not been rewritten.
     Lwt (line 55 column 18)
     Lwt_fmt (line 56 column 18)
     Lwt.(<?>) (line 113 column 11)
@@ -259,6 +263,7 @@ Make a writable directory tree:
     Lwt_list.iteri_p (line 129 column 9)
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
+    Lwt.Fail (line 179 column 9)
   Warning: lib/test_lwt_unix.ml: 1 occurrences have not been rewritten.
     Lwt_io.of_fd (line 7 column 16)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
@@ -596,6 +601,14 @@ Make a writable directory tree:
     ()
   
   module M = struct end
+  
+  let _ = Some ()
+  let _ = None
+  
+  let _ =
+    Lwt.Fail
+      (* TODO: lwt-to-direct-style: [Lwt.Fail] shouldn't be used *)
+      Not_found
 
   $ cat lib/test.mli
   open Eio.Std
@@ -637,3 +650,5 @@ Make a writable directory tree:
         inp buf
     in
     ()
+  
+  let _ = Eio.Time.Timeout

--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -223,12 +223,19 @@ Make a writable directory tree:
     Lwt_mutex.lock (line 136 column 9)
     Lwt_mutex.unlock (line 137 column 9)
     Lwt_mutex.with_lock (line 138 column 9)
-  lib/test_lwt_unix.ml: (14 occurrences)
+  lib/test_lwt_unix.ml: (21 occurrences)
     Lwt_io (line 7 column 8)
     Lwt.return (line 11 column 3)
     Lwt.let* (line 10 column 3)
     Lwt.Syntax (line 1 column 6)
+    Lwt_io.Input (line 22 column 32)
+    Lwt_io.Output (line 23 column 32)
+    Lwt_io.input (line 7 column 28)
+    Lwt_io.output (line 21 column 32)
     Lwt_io.of_fd (line 7 column 16)
+    Lwt_io.of_fd (line 21 column 13)
+    Lwt_io.of_fd (line 22 column 13)
+    Lwt_io.of_fd (line 23 column 13)
     Lwt_io.read_into (line 10 column 19)
     Lwt_unix.Timeout (line 13 column 9)
     Lwt_unix.of_unix_file_descr (line 6 column 8)
@@ -268,8 +275,6 @@ Make a writable directory tree:
     Lwt.Fail (line 147 column 5)
     Lwt.let* (line 163 column 21)
     Lwt.Fail (line 179 column 9)
-  Warning: lib/test_lwt_unix.ml: 1 occurrences have not been rewritten.
-    Lwt_io.of_fd (line 7 column 16)
   Warning: lib/test.mli: 2 occurrences have not been rewritten.
     Lwt_mutex.t (line 2 column 10)
     Lwt_mutex.t (line 3 column 10)
@@ -647,7 +652,8 @@ Make a writable directory tree:
            (* TODO: lwt-to-direct-style: Labelled argument ?set_flags was dropped. *).(
              openfile fname [ O_RDWR; O_NONBLOCK; O_APPEND ])
              0o660))
-      |> of_fd ~mode:input
+      |> fun x1 ->
+      (Eio_unix.Net.import_socket_stream x1 : [ `R | `Flow | `Close ] Std.r)
     in
     let buf = Bytes.create 1024 in
     let _n : int =
@@ -669,3 +675,12 @@ Make a writable directory tree:
       (* TODO: lwt-to-direct-style: This call to [Unix.getaddrinfo] was [Lwt_unix.getaddrinfo] before the rewrite. *)
       =
     Unix.getaddrinfo
+  
+  let _f fd =
+    (Eio_unix.Net.import_socket_stream fd : [ `W | `Flow | `Close ] Std.r)
+  
+  let _f fd =
+    (Eio_unix.Net.import_socket_stream fd : [ `R | `Flow | `Close ] Std.r)
+  
+  let _f fd =
+    (Eio_unix.Net.import_socket_stream fd : [ `W | `Flow | `Close ] Std.r)

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
@@ -173,3 +173,7 @@ module M = struct
   include Lwt.Infix
   include Lwt.Syntax
 end
+
+let _ = Lwt.Return ()
+let _ = Lwt.Sleep
+let _ = Lwt.Fail Not_found

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -17,3 +17,7 @@ let (Lwt_unix.ADDR_UNIX _ | ADDR_INET _) =
   Lwt_unix.ADDR_INET (Unix.inet_addr_any, 0)
 
 let _ = Lwt_unix.getaddrinfo
+
+let _f fd = Lwt_io.of_fd ~mode:Lwt_io.output fd
+let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Input fd
+let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Output fd

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -22,3 +22,5 @@ let _f fd = Lwt_io.of_fd ~mode:Lwt_io.output fd
 let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Input fd
 let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Output fd
 let _f out_chan = Lwt_io.write out_chan "str"
+
+let _ : Lwt_io.output_channel = Lwt_io.stdout

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -15,3 +15,5 @@ let _ : Lwt_unix.sockaddr = Lwt_unix.ADDR_UNIX ""
 
 let (Lwt_unix.ADDR_UNIX _ | ADDR_INET _) =
   Lwt_unix.ADDR_INET (Unix.inet_addr_any, 0)
+
+let _ = Lwt_unix.getaddrinfo

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -9,3 +9,5 @@ let _f fname =
   let buf = Bytes.create 1024 in
   let* _n : int = Lwt_io.read_into inp buf 0 1024 in
   Lwt.return ()
+
+let _ = Lwt_unix.Timeout

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -11,3 +11,7 @@ let _f fname =
   Lwt.return ()
 
 let _ = Lwt_unix.Timeout
+let _ : Lwt_unix.sockaddr = Lwt_unix.ADDR_UNIX ""
+
+let (Lwt_unix.ADDR_UNIX _ | ADDR_INET _) =
+  Lwt_unix.ADDR_INET (Unix.inet_addr_any, 0)

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -1,4 +1,11 @@
-let _ =
-  Unix.(openfile "foo" [O_RDWR; O_NONBLOCK; O_APPEND]) 0o660
-  |> Lwt_unix.of_unix_file_descr
-  |> Lwt_io.(of_fd ~mode:input)
+open Lwt.Syntax
+
+let _f fname =
+  let inp =
+    Unix.(openfile fname [ O_RDWR; O_NONBLOCK; O_APPEND ]) 0o660
+    |> Lwt_unix.of_unix_file_descr
+    |> Lwt_io.(of_fd ~mode:input)
+  in
+  let buf = Bytes.create 1024 in
+  let* _n : int = Lwt_io.read_into inp buf 0 1024 in
+  Lwt.return ()

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -1,0 +1,4 @@
+let _ =
+  Unix.(openfile "foo" [O_RDWR; O_NONBLOCK; O_APPEND]) 0o660
+  |> Lwt_unix.of_unix_file_descr
+  |> Lwt_io.(of_fd ~mode:input)

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test_lwt_unix.ml
@@ -21,3 +21,4 @@ let _ = Lwt_unix.getaddrinfo
 let _f fd = Lwt_io.of_fd ~mode:Lwt_io.output fd
 let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Input fd
 let _f fd = Lwt_io.of_fd ~mode:Lwt_io.Output fd
+let _f out_chan = Lwt_io.write out_chan "str"


### PR DESCRIPTION
This is a non-exhaustive translation of `Lwt_unix` and `Lwt_io` functions and types needed by ocsigenserver. This also handles `Lwt_main.run`.