### PR TITLE
Rewrite 'a Lwt.t' in let return type annotation to 'a'

### DIFF
--- a/test/lwt_to_direct_style/to_direct_style.t/run.t
+++ b/test/lwt_to_direct_style/to_direct_style.t/run.t
@@ -50,7 +50,7 @@ Make a writable directory tree:
     Lwt_unix.sleep (line 31 column 9)
     Lwt_unix.Timeout (line 37 column 15)
     Lwt_unix.with_timeout (line 35 column 16)
-  lib/test.ml: (169 occurrences)
+  lib/test.ml: (174 occurrences)
     Lwt (line 36 column 12)
     Lwt (line 55 column 18)
     Lwt (line 64 column 13)
@@ -66,6 +66,9 @@ Make a writable directory tree:
     Lwt.t (line 158 column 23)
     Lwt.t (line 158 column 38)
     Lwt.t (line 159 column 15)
+    Lwt.t (line 178 column 16)
+    Lwt.t (line 179 column 20)
+    Lwt.t (line 180 column 20)
     Lwt.new_key (line 150 column 11)
     Lwt.get (line 151 column 9)
     Lwt.with_value (line 152 column 9)
@@ -92,6 +95,8 @@ Make a writable directory tree:
     Lwt.return (line 140 column 28)
     Lwt.return (line 161 column 14)
     Lwt.fail (line 109 column 9)
+    Lwt.return_unit (line 178 column 24)
+    Lwt.return_unit (line 179 column 28)
     Lwt.fail_with (line 110 column 9)
     Lwt.fail_invalid_arg (line 118 column 33)
     Lwt.wait (line 122 column 14)
@@ -586,6 +591,12 @@ Make a writable directory tree:
     ()
   
   module M = struct end
+  
+  let _ =
+    let _ : unit Promise.t = () in
+    let _f () : unit = () in
+    let _f (x : unit Promise.t) = x in
+    ()
 
   $ cat lib/test.mli
   open Eio.Std

--- a/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
+++ b/test/lwt_to_direct_style/to_direct_style.t/src/lib/test.ml
@@ -173,3 +173,9 @@ module M = struct
   include Lwt.Infix
   include Lwt.Syntax
 end
+
+let _ =
+  let _ : unit Lwt.t = Lwt.return_unit in
+  let _f () : unit Lwt.t = Lwt.return_unit in
+  let _f (x : unit Lwt.t) = x in
+  ()


### PR DESCRIPTION
This rewrite was done in this case:

    let f : _ -> int Lwt.t = ..

and is now done in this case:

    let f _ : int Lwt.t = ..

The return type is now 'int' in both cases.