### PR TITLE
eio: Add '--eio-env-as-fiber-var'

### DIFF
--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -187,8 +187,16 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
              [%a]."
             Ocamlformat_utils.Parsing.Printast.fmt_longident ident
       | None -> ());
+      let wrap_env_fiber_var env x =
+        match eio_env_as_fiber_var with
+        | Some var_ident ->
+            mk_apply_simple
+              [ "Fiber"; "with_binding" ]
+              [ Exp.ident (mk_loc var_ident); env; mk_thunk x ]
+        | None -> x
+      in
       mk_apply_simple [ "Eio_main"; "run" ]
-        [ mk_fun ~arg_name:"env" (fun _env -> promise) ]
+        [ mk_fun ~arg_name:"env" (fun env -> wrap_env_fiber_var env promise) ]
 
     method input_io_of_fd fd =
       Exp.constraint_

--- a/bin/lwt_to_direct_style/concurrency_backend.ml
+++ b/bin/lwt_to_direct_style/concurrency_backend.ml
@@ -25,7 +25,8 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
   let get_current_switch () =
     match eio_sw_as_fiber_var with
     | Some ident ->
-        mk_apply_simple [ "Option"; "get" ]
+        mk_apply_simple
+          [ "Stdlib"; "Option"; "get" ]
           [ mk_apply_simple [ "Fiber"; "get" ] [ Exp.ident (mk_loc ident) ] ]
     | None ->
         add_comment "[sw] (of type Switch.t) must be propagated here.";
@@ -38,7 +39,8 @@ let eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var add_comment =
     let env_exp =
       match eio_env_as_fiber_var with
       | Some ident ->
-          mk_apply_simple [ "Option"; "get" ]
+          mk_apply_simple
+            [ "Stdlib"; "Option"; "get" ]
             [ mk_apply_simple [ "Fiber"; "get" ] [ Exp.ident (mk_loc ident) ] ]
       | None ->
           add_comment "[env] must be propagated from the main loop";

--- a/bin/lwt_to_direct_style/main.ml
+++ b/bin/lwt_to_direct_style/main.ml
@@ -1,5 +1,7 @@
-let main migrate eio_sw_as_fiber_var =
-  let backend = Concurrency_backend.eio ~eio_sw_as_fiber_var in
+let main migrate eio_sw_as_fiber_var eio_env_as_fiber_var =
+  let backend =
+    Concurrency_backend.eio ~eio_sw_as_fiber_var ~eio_env_as_fiber_var
+  in
   let modify_ast ~fname = Ast_rewrite.rewrite_lwt_uses ~fname ~backend in
   let units = function
     | "Lwt" -> true
@@ -31,6 +33,17 @@ let opt_eio_sw_as_fiber_var =
     & opt (some ident_conv) None
     & info ~doc ~docv:"Fiber.key" [ "eio-sw-as-fiber-var" ])
 
+let opt_eio_env_as_fiber_var =
+  let doc =
+    "Eio only: Pass the environment as a Fiber variable. It will be queried \
+     everytime the environment is needed. Argument must be a fully-qualified \
+     OCaml identifier pointing to a value of type 'Switch.t Fiber.key'."
+  in
+  Arg.(
+    value
+    & opt (some ident_conv) None
+    & info ~doc ~docv:"Fiber.key" [ "eio-env-as-fiber-var" ])
+
 let opt_migrate =
   let doc = "Modify the source code instead of printing occurrences of Lwt." in
   Arg.(value & flag & info ~doc [ "migrate" ])
@@ -41,6 +54,9 @@ let cmd =
   in
   let info = Cmd.info "lwt-to-direct-style" ~version:"%%VERSION%%" ~doc in
   Cmd.v info
-    Term.(term_result (const main $ opt_migrate $ opt_eio_sw_as_fiber_var))
+    Term.(
+      term_result
+        (const main $ opt_migrate $ opt_eio_sw_as_fiber_var
+       $ opt_eio_env_as_fiber_var))
 
 let () = exit (Cmd.eval cmd)

--- a/test/lwt_to_direct_style/eio-switch.t/run.t
+++ b/test/lwt_to_direct_style/eio-switch.t/run.t
@@ -3,16 +3,27 @@ Make a writable directory tree:
   $ cd out
 
   $ dune build @ocaml-index
-  $ lwt-to-direct-style --migrate --eio-sw-as-fiber-var Fiber_var.sw
+  $ lwt-to-direct-style --migrate --eio-sw-as-fiber-var Fiber_var.sw --eio-env-as-fiber-var Fiber_var.env
   Formatted 1 files
-  Warning: main.ml: 2 occurrences have not been rewritten.
-    Lwt_io.read (line 9 column 12)
-    Lwt_io.printf (line 10 column 3)
+  Warning: main.ml: 5 occurrences have not been rewritten.
+    Lwt_io.open_file (line 8 column 13)
+    Lwt_io.input (line 8 column 36)
+    Lwt_io.close (line 9 column 3)
+    Lwt_io.read (line 15 column 12)
+    Lwt_io.printf (line 16 column 3)
 
   $ cat main.ml
   open Eio.Std
   
   let async_process _ = ()
+  
+  let _f _ =
+    Eio.Time.with_timeout_exn (Option.get (Fiber.get Fiber_var.env))#mono_clock
+      1.0 (fun () -> 42)
+  
+  let _f fname =
+    let fd = Lwt_io.open_file ~mode:Lwt_io.input fname in
+    Lwt_io.close fd
   
   let main () =
     Fiber.fork

--- a/test/lwt_to_direct_style/eio-switch.t/run.t
+++ b/test/lwt_to_direct_style/eio-switch.t/run.t
@@ -45,6 +45,7 @@ Make a writable directory tree:
   
   let () =
     Eio_main.run (fun env ->
-        (* TODO: lwt-to-direct-style: [Eio_main.run] argument used to be a [Lwt] promise and is now a [fun]. Make sure no asynchronous or IO calls are done outside of this [fun]. *)
-        (* TODO: lwt-to-direct-style: Make sure to create a [Switch.t] and store it in fiber variable ["Fiber_var.sw"]. *)
-        main ())
+        Fiber.with_binding Fiber_var.env env (fun () ->
+            (* TODO: lwt-to-direct-style: [Eio_main.run] argument used to be a [Lwt] promise and is now a [fun]. Make sure no asynchronous or IO calls are done outside of this [fun]. *)
+            (* TODO: lwt-to-direct-style: Make sure to create a [Switch.t] and store it in fiber variable ["Fiber_var.sw"]. *)
+            main ()))

--- a/test/lwt_to_direct_style/eio-switch.t/run.t
+++ b/test/lwt_to_direct_style/eio-switch.t/run.t
@@ -18,8 +18,8 @@ Make a writable directory tree:
   let async_process _ = ()
   
   let _f _ =
-    Eio.Time.with_timeout_exn (Option.get (Fiber.get Fiber_var.env))#mono_clock
-      1.0 (fun () -> 42)
+    Eio.Time.with_timeout_exn
+      (Stdlib.Option.get (Fiber.get Fiber_var.env))#mono_clock 1.0 (fun () -> 42)
   
   let _f fname =
     let fd = Lwt_io.open_file ~mode:Lwt_io.input fname in
@@ -27,12 +27,12 @@ Make a writable directory tree:
   
   let main () =
     Fiber.fork
-      ~sw:(Option.get (Fiber.get Fiber_var.sw))
+      ~sw:(Stdlib.Option.get (Fiber.get Fiber_var.sw))
       (fun () -> async_process 1);
     let fd =
      fun ?blocking:x1 ?set_flags:x2 ->
       Eio_unix.Fd.of_unix
-        ~sw:(Option.get (Fiber.get Fiber_var.sw))
+        ~sw:(Stdlib.Option.get (Fiber.get Fiber_var.sw))
         ?blocking:x1 ~close_unix:true
         (* TODO: lwt-to-direct-style: Labelled argument ?set_flags was dropped. *)
         Unix.stdin

--- a/test/lwt_to_direct_style/eio-switch.t/run.t
+++ b/test/lwt_to_direct_style/eio-switch.t/run.t
@@ -46,6 +46,7 @@ Make a writable directory tree:
   let () =
     Eio_main.run (fun env ->
         Fiber.with_binding Fiber_var.env env (fun () ->
-            (* TODO: lwt-to-direct-style: [Eio_main.run] argument used to be a [Lwt] promise and is now a [fun]. Make sure no asynchronous or IO calls are done outside of this [fun]. *)
-            (* TODO: lwt-to-direct-style: Make sure to create a [Switch.t] and store it in fiber variable ["Fiber_var.sw"]. *)
-            main ()))
+            Switch.run ~name:"main" (fun sw ->
+                Fiber.with_binding Fiber_var.sw sw (fun () ->
+                    (* TODO: lwt-to-direct-style: [Eio_main.run] argument used to be a [Lwt] promise and is now a [fun]. Make sure no asynchronous or IO calls are done outside of this [fun]. *)
+                    main ()))))

--- a/test/lwt_to_direct_style/eio-switch.t/src/main.ml
+++ b/test/lwt_to_direct_style/eio-switch.t/src/main.ml
@@ -2,6 +2,12 @@ open Lwt.Syntax
 
 let async_process _ = Lwt.return ()
 
+let _f _ = Lwt_unix.with_timeout 1.0 (fun () -> Lwt.return 42)
+
+let _f fname =
+  let* fd = Lwt_io.open_file ~mode:Lwt_io.input fname in
+  Lwt_io.close fd
+
 let main () =
   Lwt.async (fun () -> async_process 1);
   let fd = Lwt_unix.of_unix_file_descr Unix.stdin in


### PR DESCRIPTION
This options specifies a way to query the environment in a similar way as https://github.com/Julow/lwt-to-direct-style/pull/17

`Eio_main.run` now also sets the variable if passed. It also creates a switch and initializes the `sw` variable if specified with `--eio-sw-as-fiber-var`.